### PR TITLE
Change login name to not all caps

### DIFF
--- a/steam-login/usr/share/xsessions/steam-bigpicture.desktop
+++ b/steam-login/usr/share/xsessions/steam-bigpicture.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=STEAM
+Name=Steam
 Comment=This session logs you directly to STEAM
 Exec=steam-de
 Icon=steam


### PR DESCRIPTION
The login name in the xsession file was all caps, 'STEAM' I have changed it to be 'Steam' This is more aesthetically pleasing when selecting in the DM. 
