### PR TITLE
build.sh: use fakeroot instead of chown

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,2 @@
 cd `dirname $0`
-user=`whoami`
-sudo chown -R root:root .
-sudo dpkg --build steam-login .
-sudo chown -R $user:$user .
+fakeroot dpkg --build steam-login .


### PR DESCRIPTION
fakeroot drops the requirement to be root to build the package.
