### PR TITLE
exit steam properly using the '-shutdown' command

### DIFF
--- a/steam-login/usr/bin/steam-de
+++ b/steam-login/usr/bin/steam-de
@@ -96,5 +96,5 @@ do
 done
 
 #Exit steam nicely...
-steam steam://ExitSteam
+steam -shutdown
 


### PR DESCRIPTION
This way choosing exit in the steam menu actually returns you to the display manager.
