### PR TITLE
Why is steam starting in the background?

### DIFF
--- a/steam-login/usr/bin/steam-de
+++ b/steam-login/usr/bin/steam-de
@@ -255,32 +255,37 @@ xset s off
 INFO "Execute Steam"
 INFO "Exec line: $PREFIX $PROGRAM $STEAM_ARGS"
 if [ ! -z "$PREFIX" ]; then
-        $PREFIX $PROGRAM $STEAM_ARGS &
+        $PREFIX $PROGRAM $STEAM_ARGS
 else
-        $PROGRAM $STEAM_ARGS &
+        $PROGRAM $STEAM_ARGS
 fi
 
-INFO "Wait until steam window will be visible"
-while ! check_steam_window; do
-    sleep 0.5
-    read STEAM_PID < $HOME/.steampid
-    if [ ! -d "/proc/$STEAM_PID" ]; then
-        zenity --error --text "Ops! Steam had some trouble to run. That can be a problem with steam itself or with your configuration."
-        ERRO "Ops! Steam had some trouble to run. That can be a problem with steam itself or with your configuration."
-    fi
-done
-INFO "Steam working"
+## all these lines are disabled, becouse i don't know why you would run steam in the background and then
+## use all kinds of hacky ways of testing for steam running... you could even start in the background, then use `wait`!!!
 
-INFO "Wait while steam running"
+# INFO "Wait until steam window will be visible"
+# while ! check_steam_window; do
+#     sleep 0.5
+#     read STEAM_PID < $HOME/.steampid
+#     if [ ! -d "/proc/$STEAM_PID" ]; then
+#         zenity --error --text "Ops! Steam had some trouble to run. That can be a problem with steam itself or with your configuration."
+#         ERRO "Ops! Steam had some trouble to run. That can be a problem with steam itself or with your configuration."
+#     fi
+# done
+# INFO "Steam working"
 
-# self kill on steam exit
-{
-        while [ -d "/proc/$STEAM_PID" ]; do sleep 1; done
-        kill $STEAM_DE_PID &> /dev/null
-} &
+# INFO "Wait while steam running"
 
-while check_steam_window; do
-    sleep 10
-done
+# # self kill on steam exit
+# {
+#         while [ -d "/proc/$STEAM_PID" ]; do sleep 1; done
+#         kill $STEAM_DE_PID &> /dev/null
+# } &
+
+# while check_steam_window; do
+#     sleep 10
+# done
+
+steam_de_exit
 
 exit 0


### PR DESCRIPTION
The issue this came from:
after .5 seconds, the program says steam had an error starting, because it cant find `/proc/$STEAM_PID`. And then it exits... even though steam is still starting... but all checks to see if steam is running fail, because the window it not there YET.

why are you starting steam in the background, and then checking if steam is still running? It would be way simpler to just not start it in the background.

That's all I changed here. The Steam command is not appended by `&` anymore, and all checks if steam is still running are commented out.

Another way would be to check if steam is running using pgrep. you could also save the process id and use `wait` to wait for it.